### PR TITLE
AFK Feature

### DIFF
--- a/assets/commands.json
+++ b/assets/commands.json
@@ -13,6 +13,19 @@
     ]
   },
   {
+    "name": "afk ",
+    "aliases": [],
+    "permissions": [
+      "nexus.afk"
+    ],
+    "descriptions": [
+      "Mark yourself as AFK"
+    ],
+    "arguments": [
+      ""
+    ]
+  },
+  {
     "name": "anvil ",
     "aliases": [],
     "permissions": [

--- a/nexus-api/src/main/java/space/bxteam/nexus/NexusApi.java
+++ b/nexus-api/src/main/java/space/bxteam/nexus/NexusApi.java
@@ -1,5 +1,6 @@
 package space.bxteam.nexus;
 
+import space.bxteam.nexus.feature.afk.AfkService;
 import space.bxteam.nexus.feature.chat.ChatService;
 import space.bxteam.nexus.feature.home.HomeService;
 import space.bxteam.nexus.feature.ignore.IgnoreService;
@@ -15,6 +16,8 @@ import space.bxteam.nexus.feature.warp.WarpService;
  * Main API for the Nexus plugin. Provides access to all services.
  */
 public interface NexusApi {
+    AfkService getAfkService();
+
     ChatService getChatService();
 
     HomeService getHomeService();

--- a/nexus-api/src/main/java/space/bxteam/nexus/feature/afk/AfkPlayer.java
+++ b/nexus-api/src/main/java/space/bxteam/nexus/feature/afk/AfkPlayer.java
@@ -1,0 +1,9 @@
+package space.bxteam.nexus.feature.afk;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Represents a player that is AFK.
+ */
+public record AfkPlayer(UUID playerUuid, AfkReason reason, Instant start) { }

--- a/nexus-api/src/main/java/space/bxteam/nexus/feature/afk/AfkReason.java
+++ b/nexus-api/src/main/java/space/bxteam/nexus/feature/afk/AfkReason.java
@@ -1,0 +1,22 @@
+package space.bxteam.nexus.feature.afk;
+
+/**
+ * Represents the reason why a player is AFK.
+ */
+public enum AfkReason {
+    /**
+     * This reason is used when the player is AFK due to inactivity.
+     */
+    INACTIVITY,
+
+    /**
+     * This reason is used when the player AFK mode was toggled manually by a command.
+     */
+    COMMAND,
+
+    /**
+     * This reason is used when the player is AFK due to another reason, e.g. plugin API.
+     * @apiNote This reason must be used only by 3rd party plugins that integrate with the AFK feature, not by the core.
+     */
+    OTHER
+}

--- a/nexus-api/src/main/java/space/bxteam/nexus/feature/afk/AfkService.java
+++ b/nexus-api/src/main/java/space/bxteam/nexus/feature/afk/AfkService.java
@@ -1,0 +1,56 @@
+package space.bxteam.nexus.feature.afk;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.UUID;
+
+/**
+ * Service that provides AFK functionality.
+ */
+public interface AfkService {
+    /**
+     * Switches the AFK status of the player.
+     *
+     * @param playerUuid the UUID of the player
+     * @param reason the reason for the AFK status
+     */
+    void switchAfk(UUID playerUuid, AfkReason reason);
+
+    /**
+     * Marks the player as AFK.
+     *
+     * @param playerUuid the UUID of the player
+     * @param reason the reason for the AFK status
+     */
+    void markAfk(UUID playerUuid, AfkReason reason);
+
+    /**
+     * Unmarks the player as AFK.
+     *
+     * @param playerUuid the UUID of the player
+     */
+    void unmarkAfk(UUID playerUuid);
+
+    /**
+     * Marks the player as interacting.
+     *
+     * @param playerUuid the UUID of the player
+     */
+    void markInteraction(UUID playerUuid);
+
+    /**
+     * Checks if the player is AFK.
+     *
+     * @param playerUuid the UUID of the player
+     * @return true if the player is AFK, false otherwise
+     */
+    boolean isAfk(UUID playerUuid);
+
+    /**
+     * Checks if the player is inactive.
+     *
+     * @param playerUuid the UUID of the player
+     * @return true if the player is inactive, false otherwise
+     */
+    boolean isInactive(UUID playerUuid);
+}

--- a/nexus-api/src/main/java/space/bxteam/nexus/feature/afk/event/AfkSwitchEvent.java
+++ b/nexus-api/src/main/java/space/bxteam/nexus/feature/afk/event/AfkSwitchEvent.java
@@ -6,6 +6,7 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import space.bxteam.nexus.feature.afk.AfkPlayer;
+import space.bxteam.nexus.feature.afk.AfkReason;
 
 /**
  * This event is called when a player switches their AFK status.
@@ -17,12 +18,15 @@ public class AfkSwitchEvent extends Event implements Cancellable {
     @Getter
     private final AfkPlayer afkPlayer;
     @Getter
+    private final AfkReason afkReason;
+    @Getter
     private final boolean isAfk;
     private boolean cancelled;
 
-    public AfkSwitchEvent(AfkPlayer afkPlayer, boolean isAfk) {
+    public AfkSwitchEvent(AfkPlayer afkPlayer, AfkReason afkReason, boolean isAfk) {
         super(false);
         this.afkPlayer = afkPlayer;
+        this.afkReason = afkReason;
         this.isAfk = isAfk;
     }
 

--- a/nexus-api/src/main/java/space/bxteam/nexus/feature/afk/event/AfkSwitchEvent.java
+++ b/nexus-api/src/main/java/space/bxteam/nexus/feature/afk/event/AfkSwitchEvent.java
@@ -1,0 +1,47 @@
+package space.bxteam.nexus.feature.afk.event;
+
+import lombok.Getter;
+import lombok.experimental.Accessors;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import space.bxteam.nexus.feature.afk.AfkPlayer;
+
+/**
+ * This event is called when a player switches their AFK status.
+ */
+@Accessors(fluent = false)
+public class AfkSwitchEvent extends Event implements Cancellable {
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    @Getter
+    private final AfkPlayer afkPlayer;
+    @Getter
+    private final boolean isAfk;
+    private boolean cancelled;
+
+    public AfkSwitchEvent(AfkPlayer afkPlayer, boolean isAfk) {
+        super(false);
+        this.afkPlayer = afkPlayer;
+        this.isAfk = isAfk;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+}

--- a/nexus-core/src/main/java/space/bxteam/nexus/core/NexusApiImpl.java
+++ b/nexus-core/src/main/java/space/bxteam/nexus/core/NexusApiImpl.java
@@ -3,6 +3,7 @@ package space.bxteam.nexus.core;
 import com.google.inject.Injector;
 import lombok.RequiredArgsConstructor;
 import space.bxteam.nexus.NexusApi;
+import space.bxteam.nexus.feature.afk.AfkService;
 import space.bxteam.nexus.feature.chat.ChatService;
 import space.bxteam.nexus.feature.home.HomeService;
 import space.bxteam.nexus.feature.ignore.IgnoreService;
@@ -17,6 +18,11 @@ import space.bxteam.nexus.feature.warp.WarpService;
 @RequiredArgsConstructor
 public class NexusApiImpl implements NexusApi {
     private final Injector injector;
+
+    @Override
+    public AfkService getAfkService() {
+        return this.injector.getInstance(AfkService.class);
+    }
 
     @Override
     public ChatService getChatService() {

--- a/nexus-core/src/main/java/space/bxteam/nexus/core/NexusModule.java
+++ b/nexus-core/src/main/java/space/bxteam/nexus/core/NexusModule.java
@@ -16,6 +16,7 @@ import space.bxteam.commons.adventure.processor.AdventureLegacyColorPostProcesso
 import space.bxteam.commons.adventure.processor.AdventureLegacyColorPreProcessor;
 import space.bxteam.commons.adventure.processor.AdventureUrlPostProcessor;
 import space.bxteam.nexus.core.configuration.ConfigurationManager;
+import space.bxteam.nexus.core.feature.afk.AfkServiceImpl;
 import space.bxteam.nexus.core.feature.chat.ChatServiceImpl;
 import space.bxteam.nexus.core.feature.ignore.IgnoreServiceImpl;
 import space.bxteam.nexus.core.feature.jail.JailServiceImpl;
@@ -31,6 +32,7 @@ import space.bxteam.nexus.core.feature.warp.WarpServiceImpl;
 import space.bxteam.nexus.core.configuration.plugin.PluginConfigurationProvider;
 import space.bxteam.nexus.core.integration.placeholderapi.resolver.PlaceholderRegistry;
 import space.bxteam.nexus.core.integration.placeholderapi.resolver.PlaceholderRegistryImpl;
+import space.bxteam.nexus.feature.afk.AfkService;
 import space.bxteam.nexus.feature.chat.ChatService;
 import space.bxteam.nexus.feature.home.HomeService;
 import space.bxteam.nexus.feature.ignore.IgnoreService;
@@ -75,6 +77,7 @@ public class NexusModule extends AbstractModule {
                         .preProcessor(new AdventureLegacyColorPreProcessor())
                         .build());
 
+        this.bind(AfkService.class).to(AfkServiceImpl.class);
         this.bind(ChatService.class).to(ChatServiceImpl.class);
         this.bind(WarpService.class).to(WarpServiceImpl.class);
         this.bind(HomeService.class).to(HomeServiceImpl.class);

--- a/nexus-core/src/main/java/space/bxteam/nexus/core/configuration/plugin/PluginConfiguration.java
+++ b/nexus-core/src/main/java/space/bxteam/nexus/core/configuration/plugin/PluginConfiguration.java
@@ -85,6 +85,22 @@ public class PluginConfiguration extends OkaeriConfig {
     }
 
     @Comment("")
+    private Afk afk = new Afk();
+
+    @Getter
+    public class Afk extends OkaeriConfig {
+        @Comment("Amount of interactions required to unmark the player as AFK")
+        private int interactionsRequired = 20;
+
+        @Comment("Should the player be marked as AFK after a certain time of inactivity?")
+        private boolean autoMark = true;
+        @Comment("Amount of time after which the player will be marked as AFK")
+        private Duration autoMarkTime = Duration.ofMinutes(10);
+        @Comment("Should the player be kicked from the server when marked as AFK?")
+        private boolean kickOnAfk = false;
+    }
+
+    @Comment("")
     private Spawn spawn = new Spawn();
     @Exclude
     private static final Position EMPTY_POSITION = new Position(0, 0, 0, 0.0f, 0.0f, Position.NONE_WORLD);

--- a/nexus-core/src/main/java/space/bxteam/nexus/core/feature/afk/AfkController.java
+++ b/nexus-core/src/main/java/space/bxteam/nexus/core/feature/afk/AfkController.java
@@ -1,0 +1,74 @@
+package space.bxteam.nexus.core.feature.afk;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import lombok.RequiredArgsConstructor;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.Server;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import space.bxteam.commons.adventure.AdventureUtil;
+import space.bxteam.nexus.core.configuration.plugin.PluginConfigurationProvider;
+import space.bxteam.nexus.core.integration.placeholderapi.resolver.PlaceholderRegistry;
+import space.bxteam.nexus.core.integration.placeholderapi.resolver.PlaceholderReplacer;
+import space.bxteam.nexus.core.scanner.annotations.component.Controller;
+import space.bxteam.nexus.core.translation.Translation;
+import space.bxteam.nexus.core.translation.TranslationProvider;
+import space.bxteam.nexus.event.NexusInitializeEvent;
+import space.bxteam.nexus.feature.afk.AfkService;
+import space.bxteam.nexus.feature.afk.event.AfkSwitchEvent;
+
+import java.util.stream.Stream;
+
+@Controller
+@RequiredArgsConstructor(onConstructor = @__(@Inject))
+public class AfkController implements Listener {
+    private final AfkService afkService;
+    private final PlaceholderRegistry placeholderRegistry;
+    private final PluginConfigurationProvider configurationProvider;
+    private final TranslationProvider translationProvider;
+    @Named("colorMiniMessage")
+    private final MiniMessage miniMessage;
+    private final Server server;
+
+    @EventHandler
+    public void registerPlaceholders(NexusInitializeEvent event) {
+        Stream.of(
+                PlaceholderReplacer.of("afk", (text, target) -> this.afkService.isAfk(target.getUniqueId()) ? "true" : "false"),
+                PlaceholderReplacer.of("afk_formatted", (text, target) -> {
+                    Translation translation = this.translationProvider.getCurrentTranslation();
+                    return this.afkService.isAfk(target.getUniqueId()) ? translation.afk().afkEnabledPlaceholder() : translation.afk().afkDisabledPlaceholder();
+                })
+        ).forEach(placeholderRegistry::registerPlaceholder);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    void onMove(PlayerMoveEvent event) {
+        this.afkService.markInteraction(event.getPlayer().getUniqueId());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onQuit(PlayerQuitEvent event) {
+        this.afkService.unmarkAfk(event.getPlayer().getUniqueId());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onAfkSwitch(AfkSwitchEvent event) {
+        if (!event.isAfk() || !this.configurationProvider.configuration().afk().kickOnAfk()) {
+            return;
+        }
+
+        Player player = this.server.getPlayer(event.getAfkPlayer().playerUuid());
+
+        if (player == null) {
+            return;
+        }
+
+        Translation translation = this.translationProvider.getCurrentTranslation();
+        player.kickPlayer(AdventureUtil.SECTION_SERIALIZER.serialize(this.miniMessage.deserialize(translation.afk().afkKickReason())));
+    }
+}

--- a/nexus-core/src/main/java/space/bxteam/nexus/core/feature/afk/AfkController.java
+++ b/nexus-core/src/main/java/space/bxteam/nexus/core/feature/afk/AfkController.java
@@ -19,6 +19,7 @@ import space.bxteam.nexus.core.scanner.annotations.component.Controller;
 import space.bxteam.nexus.core.translation.Translation;
 import space.bxteam.nexus.core.translation.TranslationProvider;
 import space.bxteam.nexus.event.NexusInitializeEvent;
+import space.bxteam.nexus.feature.afk.AfkReason;
 import space.bxteam.nexus.feature.afk.AfkService;
 import space.bxteam.nexus.feature.afk.event.AfkSwitchEvent;
 
@@ -68,7 +69,9 @@ public class AfkController implements Listener {
             return;
         }
 
-        Translation translation = this.translationProvider.getCurrentTranslation();
-        player.kickPlayer(AdventureUtil.SECTION_SERIALIZER.serialize(this.miniMessage.deserialize(translation.afk().afkKickReason())));
+        if (event.getAfkReason() == AfkReason.INACTIVITY) {
+            Translation translation = this.translationProvider.getCurrentTranslation();
+            player.kickPlayer(AdventureUtil.SECTION_SERIALIZER.serialize(this.miniMessage.deserialize(translation.afk().afkKickReason())));
+        }
     }
 }

--- a/nexus-core/src/main/java/space/bxteam/nexus/core/feature/afk/AfkServiceImpl.java
+++ b/nexus-core/src/main/java/space/bxteam/nexus/core/feature/afk/AfkServiceImpl.java
@@ -1,0 +1,104 @@
+package space.bxteam.nexus.core.feature.afk;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import lombok.RequiredArgsConstructor;
+import space.bxteam.nexus.core.configuration.plugin.PluginConfigurationProvider;
+import space.bxteam.nexus.core.event.EventCaller;
+import space.bxteam.nexus.core.multification.MultificationManager;
+import space.bxteam.nexus.feature.afk.AfkPlayer;
+import space.bxteam.nexus.feature.afk.AfkReason;
+import space.bxteam.nexus.feature.afk.AfkService;
+import space.bxteam.nexus.feature.afk.event.AfkSwitchEvent;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Singleton
+@RequiredArgsConstructor(onConstructor = @__(@Inject))
+public class AfkServiceImpl implements AfkService {
+    private final PluginConfigurationProvider configurationProvider;
+    private final MultificationManager multificationManager;
+    private final EventCaller eventCaller;
+
+    private final Map<UUID, AfkPlayer> afkPlayers = new HashMap<>();
+    private final Map<UUID, Integer> interactionsCount = new HashMap<>();
+    private final Map<UUID, Instant> lastInteraction = new HashMap<>();
+
+    @Override
+    public void switchAfk(UUID playerUuid, AfkReason reason) {
+        if (this.isAfk(playerUuid)) {
+            this.unmarkAfk(playerUuid);
+        } else {
+            this.markAfk(playerUuid, reason);
+        }
+    }
+
+    @Override
+    public void markAfk(UUID playerUuid, AfkReason reason) {
+        AfkPlayer afkPlayer = new AfkPlayer(playerUuid, reason, Instant.now());
+        AfkSwitchEvent event = this.eventCaller.callEvent(new AfkSwitchEvent(afkPlayer, true));
+
+        if (event.isCancelled()) {
+            return;
+        }
+
+        this.afkPlayers.put(playerUuid, afkPlayer);
+        this.sendFeedback(playerUuid, true);
+    }
+
+    @Override
+    public void unmarkAfk(UUID playerUuid) {
+        AfkPlayer afkPlayer = this.afkPlayers.get(playerUuid);
+
+        if (afkPlayer == null) {
+            return;
+        }
+
+        AfkSwitchEvent event = this.eventCaller.callEvent(new AfkSwitchEvent(afkPlayer, false));
+
+        if (event.isCancelled()) {
+            return;
+        }
+
+        this.afkPlayers.remove(playerUuid);
+        this.interactionsCount.remove(playerUuid);
+        this.lastInteraction.remove(playerUuid);
+        this.sendFeedback(playerUuid, false);
+    }
+
+    @Override
+    public void markInteraction(UUID playerUuid) {
+        this.lastInteraction.put(playerUuid, Instant.now());
+
+        if (this.isAfk(playerUuid)) {
+            int count = this.interactionsCount.merge(playerUuid, 1, Integer::sum);
+
+            if (count >= this.configurationProvider.configuration().afk().interactionsRequired()) {
+                this.unmarkAfk(playerUuid);
+            }
+        }
+    }
+
+    @Override
+    public boolean isAfk(UUID playerUuid) {
+        return this.afkPlayers.containsKey(playerUuid);
+    }
+
+    @Override
+    public boolean isInactive(UUID playerUuid) {
+        Instant lastInteraction = this.lastInteraction.get(playerUuid);
+
+        return lastInteraction != null && Duration.between(lastInteraction, Instant.now()).compareTo(this.configurationProvider.configuration().afk().autoMarkTime()) >= 0;
+    }
+
+    private void sendFeedback(UUID playerUuid, boolean isAfk) {
+        this.multificationManager.create()
+                .player(playerUuid)
+                .notice(translation -> isAfk ? translation.afk().afkOn() : translation.afk().afkOff())
+                .send();
+    }
+}

--- a/nexus-core/src/main/java/space/bxteam/nexus/core/feature/afk/AfkServiceImpl.java
+++ b/nexus-core/src/main/java/space/bxteam/nexus/core/feature/afk/AfkServiceImpl.java
@@ -40,7 +40,7 @@ public class AfkServiceImpl implements AfkService {
     @Override
     public void markAfk(UUID playerUuid, AfkReason reason) {
         AfkPlayer afkPlayer = new AfkPlayer(playerUuid, reason, Instant.now());
-        AfkSwitchEvent event = this.eventCaller.callEvent(new AfkSwitchEvent(afkPlayer, true));
+        AfkSwitchEvent event = this.eventCaller.callEvent(new AfkSwitchEvent(afkPlayer, reason, true));
 
         if (event.isCancelled()) {
             return;
@@ -58,7 +58,7 @@ public class AfkServiceImpl implements AfkService {
             return;
         }
 
-        AfkSwitchEvent event = this.eventCaller.callEvent(new AfkSwitchEvent(afkPlayer, false));
+        AfkSwitchEvent event = this.eventCaller.callEvent(new AfkSwitchEvent(afkPlayer, afkPlayer.reason(), false));
 
         if (event.isCancelled()) {
             return;

--- a/nexus-core/src/main/java/space/bxteam/nexus/core/feature/afk/AfkTask.java
+++ b/nexus-core/src/main/java/space/bxteam/nexus/core/feature/afk/AfkTask.java
@@ -1,0 +1,43 @@
+package space.bxteam.nexus.core.feature.afk;
+
+import com.google.inject.Inject;
+import lombok.RequiredArgsConstructor;
+import org.bukkit.Server;
+import org.bukkit.entity.Player;
+import space.bxteam.nexus.core.configuration.plugin.PluginConfigurationProvider;
+import space.bxteam.nexus.core.scanner.annotations.component.Task;
+import space.bxteam.nexus.feature.afk.AfkReason;
+import space.bxteam.nexus.feature.afk.AfkService;
+
+import java.util.UUID;
+
+@Task(delay = 1200L, period = 1200L)
+@RequiredArgsConstructor(onConstructor = @__(@Inject))
+public class AfkTask implements Runnable {
+    private final AfkService afkService;
+    private final PluginConfigurationProvider configurationProvider;
+    private final Server server;
+
+    @Override
+    public void run() {
+        this.markInactivePlayers();
+    }
+
+    private void markInactivePlayers() {
+        if (!this.configurationProvider.configuration().afk().autoMark()) {
+            return;
+        }
+
+        for (Player player : this.server.getOnlinePlayers()) {
+            UUID playerUuid = player.getUniqueId();
+
+            if (this.afkService.isAfk(playerUuid)) {
+                continue;
+            }
+
+            if (this.afkService.isInactive(playerUuid)) {
+                this.afkService.markAfk(playerUuid, AfkReason.INACTIVITY);
+            }
+        }
+    }
+}

--- a/nexus-core/src/main/java/space/bxteam/nexus/core/feature/afk/command/AfkCommand.java
+++ b/nexus-core/src/main/java/space/bxteam/nexus/core/feature/afk/command/AfkCommand.java
@@ -1,0 +1,29 @@
+package space.bxteam.nexus.core.feature.afk.command;
+
+import com.google.inject.Inject;
+import dev.rollczi.litecommands.annotations.command.Command;
+import dev.rollczi.litecommands.annotations.context.Context;
+import dev.rollczi.litecommands.annotations.execute.Execute;
+import dev.rollczi.litecommands.annotations.permission.Permission;
+import lombok.RequiredArgsConstructor;
+import org.bukkit.entity.Player;
+import space.bxteam.nexus.annotations.scan.command.CommandDocs;
+import space.bxteam.nexus.feature.afk.AfkReason;
+import space.bxteam.nexus.feature.afk.AfkService;
+
+import java.util.UUID;
+
+@Command(name = "afk")
+@Permission("nexus.afk")
+@RequiredArgsConstructor(onConstructor = @__(@Inject))
+public class AfkCommand {
+    private final AfkService afkService;
+
+    @Execute
+    @CommandDocs(description = "Mark yourself as AFK")
+    void execute(@Context Player player) {
+        UUID playerUuid = player.getUniqueId();
+
+        this.afkService.switchAfk(playerUuid, AfkReason.COMMAND);
+    }
+}

--- a/nexus-core/src/main/java/space/bxteam/nexus/core/translation/Translation.java
+++ b/nexus-core/src/main/java/space/bxteam/nexus/core/translation/Translation.java
@@ -75,6 +75,18 @@ public interface Translation {
         List<String> fullServerSlots();
     }
 
+    AfkSection afk();
+
+    interface AfkSection {
+        Notice afkOn();
+        Notice afkOff();
+
+        String afkKickReason();
+
+        String afkEnabledPlaceholder();
+        String afkDisabledPlaceholder();
+    }
+
     InventorySection inventory();
 
     interface InventorySection {

--- a/nexus-core/src/main/java/space/bxteam/nexus/core/translation/implementation/ENTranslation.java
+++ b/nexus-core/src/main/java/space/bxteam/nexus/core/translation/implementation/ENTranslation.java
@@ -150,6 +150,22 @@ public class ENTranslation extends OkaeriConfig implements Translation {
         );
     }
 
+    @Comment({"", "This section is responsible for the AFK-related messages."})
+    public ENAfkSection afk = new ENAfkSection();
+
+    @Getter
+    public class ENAfkSection extends OkaeriConfig implements AfkSection {
+        public Notice afkOn = Notice.chat("<green>You are now AFK!");
+        public Notice afkOff = Notice.chat("<green>You are no longer AFK!");
+
+        @Comment("")
+        public String afkKickReason = "<dark_red>You have been kicked for being AFK!";
+
+        @Comment({"", "This strings will be displayed in afk placeholders to indicate the AFK status."})
+        public String afkEnabledPlaceholder = "<gray>AFK";
+        public String afkDisabledPlaceholder = "";
+    }
+
     @Comment({"", "This section is responsible for the inventory-related messages."})
     public ENInventorySection inventory = new ENInventorySection();
 

--- a/nexus-core/src/main/java/space/bxteam/nexus/core/translation/implementation/RUTranslation.java
+++ b/nexus-core/src/main/java/space/bxteam/nexus/core/translation/implementation/RUTranslation.java
@@ -150,6 +150,22 @@ public class RUTranslation extends OkaeriConfig implements Translation {
         );
     }
 
+    @Comment({"", "Эта секция отвечает за сообщения, связанные с AFK."})
+    public RUAfkSection afk = new RUAfkSection();
+
+    @Getter
+    public class RUAfkSection extends OkaeriConfig implements AfkSection {
+        public Notice afkOn = Notice.chat("<green>Вы теперь AFK!");
+        public Notice afkOff = Notice.chat("<green>Вы больше не AFK!");
+
+        @Comment("")
+        public String afkKickReason = "<dark_red>Вы были кикнуты за AFK!";
+
+        @Comment({"", "Эти сообщения используются для плейсхолдеров"})
+        public String afkEnabledPlaceholder = "<gray>AFK";
+        public String afkDisabledPlaceholder = "";
+    }
+
     @Comment({"", "Этот раздел отвечает за сообщения, связанные с инвентарем."})
     public RUInventorySection inventory = new RUInventorySection();
 


### PR DESCRIPTION
This pull request introduces a new AFK (Away From Keyboard) feature to the Nexus project. The changes include the addition of new commands, services, events, and configuration options to support marking players as AFK and handling their AFK status.

Key changes include:

### AFK Feature Implementation:
* Added `AfkPlayer` record to represent a player that is AFK (`nexus-api/src/main/java/space/bxteam/nexus/feature/afk/AfkPlayer.java`).
* Introduced `AfkReason` enum to specify reasons for AFK status (`nexus-api/src/main/java/space/bxteam/nexus/feature/afk/AfkReason.java`).
* Created `AfkService` interface to provide AFK functionality (`nexus-api/src/main/java/space/bxteam/nexus/feature/afk/AfkService.java`).
* Implemented `AfkServiceImpl` class to handle AFK logic (`nexus-core/src/main/java/space/bxteam/nexus/core/feature/afk/AfkServiceImpl.java`).

### AFK Event Handling:
* Added `AfkSwitchEvent` to handle AFK status changes (`nexus-api/src/main/java/space/bxteam/nexus/feature/afk/event/AfkSwitchEvent.java`).
* Implemented `AfkController` to listen for player events and manage AFK status (`nexus-core/src/main/java/space/bxteam/nexus/core/feature/afk/AfkController.java`).

### Configuration and Commands:
* Added configuration options for AFK feature in `PluginConfiguration` (`nexus-core/src/main/java/space/bxteam/nexus/core/configuration/plugin/PluginConfiguration.java`).
* Introduced `AfkCommand` to allow players to mark themselves as AFK (`nexus-core/src/main/java/space/bxteam/nexus/core/feature/afk/command/AfkCommand.java`).

### Miscellaneous:
* Registered `AfkService` in `NexusModule` (`nexus-core/src/main/java/space/bxteam/nexus/core/NexusModule.java`).
* Updated translation files to include AFK-related messages (`nexus-core/src/main/java/space/bxteam/nexus/core/translation/implementation/ENTranslation.java`, `nexus-core/src/main/java/space/bxteam/nexus/core/translation/implementation/RUTranslation.java`). [[1]](diffhunk://#diff-0aa24dbefe12dca47ad9c0eb7d15c9a059147a67f225e92972b2beb2c82ef757R153-R168) [[2]](diffhunk://#diff-36eb90360d11d7d8983ddec0e1f697b1666e5e5f24fe46eedf33ca9e318afa2dR153-R168)